### PR TITLE
Copymake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "chessing"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "fancy-regex",
  "fastrand",
  "heapless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+arrayvec = "0.7.6"
 fancy-regex = "0.14.0"
 fastrand = "2.3.0"
 heapless = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pub trait PieceProcessor<T : BitInt> {
     fn process(&self, board: &mut Board<T>, piece_index: usize) {}
     
     fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action>;
-    fn make_move(&self, board: &mut Board<T>, action: Action) -> HistoryState<T>;
+    fn make_move(&self, board: &mut Board<T>, action: Action);
 
     /// Only useful for chess; allows us to optimize checks
     fn capture_mask(&self, board: &mut Board<T>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T> {

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Implementing a Game requires processing distinct logic for pieces and games.
 ### PieceRules
 
 ```rs
-pub trait PieceRules<T : BitInt> {
-    fn process(&self, board: &mut Board<T>, piece_index: usize) {}
+pub trait PieceRules<T: BitInt, const N: usize> {
+    fn process(&self, board: &mut Board<T, N>, piece_index: usize) {}
     
-    fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action>;
-    fn make_move(&self, board: &mut Board<T>, action: Action);
+    fn list_actions(&self, board: &mut Board<T, N>, piece_index: usize) -> Vec<Action>;
+    fn make_move(&self, board: &mut Board<T, N>, action: Action);
 
     /// Only useful for chess; allows us to optimize checks
-    fn capture_mask(&self, board: &mut Board<T>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T> {
+    fn capture_mask(&self, board: &mut Board<T, N>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T> {
         BitBoard::empty()
     }
 }
@@ -90,11 +90,11 @@ let rook_ind = board.find_piece("rook");
 ### GameRules
 
 ```rs
-pub trait GameRules<T : BitInt> {
+pub trait GameRules<T: BitInt, const N: usize> {
     fn is_legal(&self, board: &mut Board<T>) -> bool;
-    fn load(&self, board: &mut Board<T>, pos: &str);
+    fn load(&self, board: &mut Board<T, N>, pos: &str);
 
-    fn game_state(&self, board: &mut Board<T>, legal_actions: &[Action]) -> GameState;
+    fn game_state(&self, board: &mut Board<T, N>, legal_actions: &[Action]) -> GameState;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Games to be implemented:
 - [Shogi](https://en.wikipedia.org/wiki/Shogi)
 - [Ataxx](https://en.wikipedia.org/wiki/Ataxx)
 
-Additionally, other chess-compatible games can be implemented within this framework by implementing `GameProcessor` and `PieceProcessor`.
+Additionally, other chess-compatible games can be implemented within this framework by implementing `GameRules` and `PieceRules`.
 
 ## Quickstart
 
@@ -58,10 +58,10 @@ for action in board.list_actions() {
 
 Implementing a Game requires processing distinct logic for pieces and games.
 
-### PieceProcessor
+### PieceRules
 
 ```rs
-pub trait PieceProcessor<T : BitInt> {
+pub trait PieceRules<T : BitInt> {
     fn process(&self, board: &mut Board<T>, piece_index: usize) {}
     
     fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action>;
@@ -74,7 +74,7 @@ pub trait PieceProcessor<T : BitInt> {
 }
 ```
 
-`PieceProcessor` is how you can define pieces and piece behaviors.
+`PieceRules` is how you can define pieces and piece behaviors.
 
 - `process` is called after a board is setup, and provides a chance to cache piece moves or otherwise process the board.
 - `list_actions` lists actions that can be made with the piece.
@@ -87,10 +87,10 @@ Some pieces require other piece types to generate specific moves. For instance, 
 let rook_ind = board.find_piece("rook");
 ```
 
-### GameProcessor
+### GameRules
 
 ```rs
-pub trait GameProcessor<T : BitInt> {
+pub trait GameRules<T : BitInt> {
     fn is_legal(&self, board: &mut Board<T>) -> bool;
     fn load(&self, board: &mut Board<T>, pos: &str);
 
@@ -98,7 +98,7 @@ pub trait GameProcessor<T : BitInt> {
 }
 ```
 
-`GameProcessor` is how you define full game behaviors.
+`GameRules` is how you define full game behaviors.
 
 - `is_legal` checks if a board position after a move is made is legal. For instance in Chess, a position is illegal if after a side makes a move, that team's king is under attack.
 - `load` allows for constructing board positions from a string, say a FEN in chess.

--- a/src/chess/mod.rs
+++ b/src/chess/mod.rs
@@ -222,8 +222,8 @@ impl<T : BitInt> GameRules<T> for ChessProcessor {
         let mut en_passant = "-".to_string();
     
         if let Some(ActionRecord::Action(last_move)) = board.history.last() {
-            let last_piece_index = board.state.mailbox[last_move.to as usize] - 1;
-            let was_pawn_move = last_piece_index == PAWN as u8;
+            let last_piece_index = board.state.piece_at(last_move.to).expect("Found en passant piece");
+            let was_pawn_move = last_piece_index == PAWN;
     
             if was_pawn_move {
                 let diff = last_move.to.abs_diff(last_move.from);
@@ -309,15 +309,17 @@ impl<T : BitInt> GameRules<T> for ChessProcessor {
         let mut en_passant = false;
 
         if let Some(ActionRecord::Action(last_move)) = board.history.last() {
-            let last_piece_index = board.state.mailbox[last_move.to as usize] - 1;
-            let was_pawn_move = last_piece_index == PAWN as u8;
-    
-            if was_pawn_move {
-                let was_double_move = last_move.to.abs_diff(last_move.from) == 16;
-                if was_double_move {
-                    en_passant = true;
-                    let team_index = board.state.moving_team.index();
-                    attrs.push((last_move.to as usize) + (squares * team_index) + features);
+            let last_piece_index = board.state.piece_at(last_move.to);
+            if let Some(last_piece_index) = last_piece_index {
+                let was_pawn_move = last_piece_index == PAWN;
+        
+                if was_pawn_move {
+                    let was_double_move = last_move.to.abs_diff(last_move.from) == 16;
+                    if was_double_move {
+                        en_passant = true;
+                        let team_index = board.state.moving_team.index();
+                        attrs.push((last_move.to as usize) + (squares * team_index) + features);
+                    }
                 }
             }
         }

--- a/src/chess/mod.rs
+++ b/src/chess/mod.rs
@@ -136,7 +136,7 @@ impl<T : BitInt> GameProcessor<T> for ChessProcessor {
                 Team::Black => en_passant - width // down 1
             };
 
-            board.state.history.push(ActionRecord::Action(Action::from(one_back, one_forward, pawn_ind as u8).with_info(1)));
+            board.history.push(ActionRecord::Action(Action::from(one_back, one_forward, pawn_ind as u8).with_info(1)));
         }
     }
 
@@ -222,7 +222,7 @@ impl<T : BitInt> GameProcessor<T> for ChessProcessor {
         // 4. En Passant
         let mut en_passant = "-".to_string();
     
-        if let Some(ActionRecord::Action(last_move)) = board.state.history.last() {
+        if let Some(ActionRecord::Action(last_move)) = board.history.last() {
             let pawn_ind = board.required_pieces[2];
             let last_piece_index = board.state.mailbox[last_move.to as usize] - 1;
             let was_pawn_move = last_piece_index == pawn_ind as u8;
@@ -312,7 +312,7 @@ impl<T : BitInt> GameProcessor<T> for ChessProcessor {
 
         let mut en_passant = false;
 
-        if let Some(ActionRecord::Action(last_move)) = board.state.history.last() {
+        if let Some(ActionRecord::Action(last_move)) = board.history.last() {
             let pawn_ind = board.required_pieces[2];
             let last_piece_index = board.state.mailbox[last_move.to as usize] - 1;
             let was_pawn_move = last_piece_index == pawn_ind as u8;

--- a/src/chess/pieces/king.rs
+++ b/src/chess/pieces/king.rs
@@ -1,19 +1,8 @@
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{index_to_square, make_chess_move, Action, HistoryState, HistoryUpdate::{self}}, piece::{Piece, PieceProcessor}, Board, BoardState, Team}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{index_to_square, make_chess_move, Action}, piece::{Piece, PieceProcessor}, Board, BoardState, Team}};
 
-fn make_castling_move<T : BitInt>(state: &mut BoardState<T>, action: Action) -> HistoryState<T> {
-    let mut updates: Vec<HistoryUpdate<T>> = Vec::with_capacity(7);
-    
+fn make_castling_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
     let piece_index = state.mailbox[action.from as usize] - 1;
     let rook_ind = state.mailbox[action.to as usize] - 1;
-
-    if state.moving_team == Team::White {
-        updates.push(HistoryUpdate::White(state.white));
-    } else {
-        updates.push(HistoryUpdate::Black(state.black));
-    }
-
-    updates.push(HistoryUpdate::Piece(piece_index, state.pieces[piece_index as usize]));
-    updates.push(HistoryUpdate::Piece(rook_ind as u8, state.pieces[rook_ind as usize]));
 
     // This isn't Fischer-Random compatible yet.
 
@@ -22,11 +11,6 @@ fn make_castling_move<T : BitInt>(state: &mut BoardState<T>, action: Action) -> 
     } else {
         (action.from - 2, action.from - 1)
     };
-
-    updates.push(HistoryUpdate::Mailbox(action.from, piece_index + 1));
-    updates.push(HistoryUpdate::Mailbox(action.to, rook_ind as u8 + 1));
-    updates.push(HistoryUpdate::Mailbox(relocated_king, 0));
-    updates.push(HistoryUpdate::Mailbox(relocated_rook, 0));
 
     let king = BitBoard::index(action.from);
     let rook = BitBoard::index(action.to);
@@ -46,8 +30,6 @@ fn make_castling_move<T : BitInt>(state: &mut BoardState<T>, action: Action) -> 
     state.mailbox[action.to as usize] = 0;
     state.mailbox[relocated_king as usize] = piece_index + 1;
     state.mailbox[relocated_rook as usize] = rook_ind as u8 + 1;
-
-    HistoryState(updates)
 }
 
 pub struct KingProcess;
@@ -164,7 +146,7 @@ impl<T : BitInt> PieceProcessor<T> for KingProcess {
         }
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) -> HistoryState<T> {
+    fn make_move(&self, board: &mut Board<T>, action: Action) {
         if action.info == 0 {
             make_chess_move(&mut board.state, action)
         } else {

--- a/src/chess/pieces/king.rs
+++ b/src/chess/pieces/king.rs
@@ -1,8 +1,8 @@
 use crate::{bitboard::{BitBoard, BitInt}, chess::ROOK, game::{action::{index_to_square, make_chess_move, Action}, piece::{Piece, PieceRules}, Board, BoardState, Game, Team}};
 
 fn make_castling_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
-    let piece_index = state.mailbox[action.from as usize] - 1;
-    let rook_ind = state.mailbox[action.to as usize] - 1;
+    let piece_index = action.piece as usize;
+    let rook_ind = state.piece_at(action.to).expect("Rook must exist in castling move");
 
     // This isn't Fischer-Random compatible yet.
 
@@ -25,11 +25,6 @@ fn make_castling_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
     } else {
         state.black = state.black.xor(king).xor(rook).or(king_relocated).or(rook_relocated);
     }
-
-    state.mailbox[action.from as usize] = 0;
-    state.mailbox[action.to as usize] = 0;
-    state.mailbox[relocated_king as usize] = piece_index + 1;
-    state.mailbox[relocated_rook as usize] = rook_ind as u8 + 1;
 }
 
 pub struct KingRules;

--- a/src/chess/pieces/king.rs
+++ b/src/chess/pieces/king.rs
@@ -1,6 +1,6 @@
 use crate::{bitboard::{BitBoard, BitInt}, chess::ROOK, game::{action::{index_to_square, make_chess_move, Action}, piece::{Piece, PieceRules}, Board, BoardState, Game, Team}};
 
-fn make_castling_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
+fn make_castling_move<T: BitInt, const N: usize>(state: &mut BoardState<T, N>, action: Action) {
     let piece_index = action.piece as usize;
     let rook_ind = state.piece_at(action.to).expect("Rook must exist in castling move");
 
@@ -29,8 +29,8 @@ fn make_castling_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
 
 pub struct KingRules;
 
-impl<T : BitInt> PieceRules<T> for KingRules {
-    fn process(&self, game: &mut Game<T>, piece_index: usize) {
+impl<T: BitInt, const N: usize> PieceRules<T, N> for KingRules {
+    fn process(&self, game: &mut Game<T, N>, piece_index: usize) {
         let edges = game.edges[0];
         game.lookup[piece_index] = vec![ vec![ ] ];
 
@@ -50,7 +50,7 @@ impl<T : BitInt> PieceRules<T> for KingRules {
         }
     }
 
-    fn capture_mask(&self, board: &mut Board<T>, piece_index: usize, _: BitBoard<T>) -> BitBoard<T> {
+    fn capture_mask(&self, board: &mut Board<T, N>, piece_index: usize, _: BitBoard<T>) -> BitBoard<T> {
         let mut mask = BitBoard::empty();
         let moving_team = board.state.team_to_move();
         for king in board.state.pieces[piece_index].and(moving_team).iter() {
@@ -59,7 +59,7 @@ impl<T : BitInt> PieceRules<T> for KingRules {
         mask
     }
 
-    fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action> {
+    fn list_actions(&self, board: &mut Board<T, N>, piece_index: usize) -> Vec<Action> {
         let moving_team = board.state.team_to_move();
         let mut actions: Vec<Action> = Vec::with_capacity(8);
         let piece = piece_index as u8;
@@ -106,7 +106,7 @@ impl<T : BitInt> PieceRules<T> for KingRules {
         actions
     }
 
-    fn display_action(&self, board: &mut Board<T>, action: Action) -> Vec<String> {
+    fn display_action(&self, board: &mut Board<T, N>, action: Action) -> Vec<String> {
         let display = format!("{}{}", index_to_square(action.from), index_to_square(action.to));
         if BitBoard::index(action.to).and(board.state.team_to_move()).is_set() {
             let king_dest = if action.to > action.from { action.from + 2 } else { action.from - 2 };
@@ -124,7 +124,7 @@ impl<T : BitInt> PieceRules<T> for KingRules {
         }
     }
 
-    fn display_uci_action(&self, board: &mut Board<T>, action: Action) -> String {
+    fn display_uci_action(&self, board: &mut Board<T, N>, action: Action) -> String {
         if BitBoard::index(action.to).and(board.state.team_to_move()).is_set() {
             let king_dest = if action.to > action.from { action.from + 2 } else { action.from - 2 };
             let alternate_display = format!("{}{}", index_to_square(action.from), index_to_square(king_dest));
@@ -137,7 +137,7 @@ impl<T : BitInt> PieceRules<T> for KingRules {
         }
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) {
+    fn make_move(&self, board: &mut Board<T, N>, action: Action) {
         if action.info == 0 {
             make_chess_move(&mut board.state, action)
         } else {
@@ -146,6 +146,6 @@ impl<T : BitInt> PieceRules<T> for KingRules {
     }
 }
 
-pub fn create_king<T : BitInt>() -> Piece<T> {
+pub fn create_king<T: BitInt, const N: usize>() -> Piece<T, N> {
     Piece::new("k", "king", Box::new(KingRules))
 }

--- a/src/chess/pieces/knight.rs
+++ b/src/chess/pieces/knight.rs
@@ -3,8 +3,8 @@ use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Actio
 
 pub struct KnightRules;
 
-impl<T : BitInt> PieceRules<T> for KnightRules {
-    fn process(&self, game: &mut Game<T>, piece_index: usize) {
+impl<T: BitInt, const N: usize> PieceRules<T, N> for KnightRules {
+    fn process(&self, game: &mut Game<T, N>, piece_index: usize) {
         let edges = game.edges[0];
         let deep_edges = game.edges[1];
         game.lookup[piece_index] = vec![ vec![] ];
@@ -28,7 +28,7 @@ impl<T : BitInt> PieceRules<T> for KnightRules {
         }
     }
     
-    fn capture_mask(&self, board: &mut Board<T>, piece_index: usize, _: BitBoard<T>) -> BitBoard<T> {
+    fn capture_mask(&self, board: &mut Board<T, N>, piece_index: usize, _: BitBoard<T>) -> BitBoard<T> {
         let mut mask = BitBoard::empty();
         let moving_team = board.state.team_to_move();
         for knight in board.state.pieces[piece_index].and(moving_team).iter() {
@@ -38,7 +38,7 @@ impl<T : BitInt> PieceRules<T> for KnightRules {
     }
 
 
-    fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action> {
+    fn list_actions(&self, board: &mut Board<T, N>, piece_index: usize) -> Vec<Action> {
         let moving_team = board.state.team_to_move();
         let mut actions: Vec<Action> = Vec::with_capacity(8);
 
@@ -54,11 +54,11 @@ impl<T : BitInt> PieceRules<T> for KnightRules {
         actions
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) {
+    fn make_move(&self, board: &mut Board<T, N>, action: Action) {
         make_chess_move(&mut board.state, action)
     }
 }
 
-pub fn create_knight<T : BitInt>() -> Piece<T> {
+pub fn create_knight<T: BitInt, const N: usize>() -> Piece<T, N> {
     Piece::new("n", "knight", Box::new(KnightRules))
 }

--- a/src/chess/pieces/knight.rs
+++ b/src/chess/pieces/knight.rs
@@ -1,5 +1,5 @@
 
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action, HistoryState}, piece::{Piece, PieceProcessor}, Board}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceProcessor}, Board}};
 
 pub struct KnightProcess;
 
@@ -54,7 +54,7 @@ impl<T : BitInt> PieceProcessor<T> for KnightProcess {
         actions
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) -> HistoryState<T> {
+    fn make_move(&self, board: &mut Board<T>, action: Action) {
         make_chess_move(&mut board.state, action)
     }
 }

--- a/src/chess/pieces/knight.rs
+++ b/src/chess/pieces/knight.rs
@@ -1,13 +1,13 @@
 
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceProcessor}, Board}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceRules}, Board, Game}};
 
-pub struct KnightProcess;
+pub struct KnightRules;
 
-impl<T : BitInt> PieceProcessor<T> for KnightProcess {
-    fn process(&self, board: &mut Board<T>, piece_index: usize) {
-        let edges = board.edges[0];
-        let deep_edges = board.edges[1];
-        board.lookup[piece_index] = vec![ vec![] ];
+impl<T : BitInt> PieceRules<T> for KnightRules {
+    fn process(&self, game: &mut Game<T>, piece_index: usize) {
+        let edges = game.edges[0];
+        let deep_edges = game.edges[1];
+        game.lookup[piece_index] = vec![ vec![] ];
 
         for index in 0..64 {
             let knight = BitBoard::index(index);
@@ -24,7 +24,7 @@ impl<T : BitInt> PieceProcessor<T> for KnightProcess {
             let vertical_moves = vertical.and_not(edges.right).right(1).or(vertical.and_not(edges.left).left(1));
 
             let moves = horizontal_moves.or(vertical_moves);
-            board.lookup[piece_index][0].push(moves);
+            game.lookup[piece_index][0].push(moves);
         }
     }
     
@@ -32,7 +32,7 @@ impl<T : BitInt> PieceProcessor<T> for KnightProcess {
         let mut mask = BitBoard::empty();
         let moving_team = board.state.team_to_move();
         for knight in board.state.pieces[piece_index].and(moving_team).iter() {
-            mask = mask.or(board.lookup[piece_index][0][knight as usize]);
+            mask = mask.or(board.game.lookup[piece_index][0][knight as usize]);
         }
         mask
     }
@@ -45,7 +45,7 @@ impl<T : BitInt> PieceProcessor<T> for KnightProcess {
         let piece = piece_index as u8;
         for knight in board.state.pieces[piece_index].and(moving_team).iter() {
             let pos = knight as u8;
-            let moves = board.lookup[piece_index][0][knight as usize].and_not(moving_team);
+            let moves = board.game.lookup[piece_index][0][knight as usize].and_not(moving_team);
             for movement in moves.iter() {
                 actions.push(Action::from(pos, movement as u8, piece))
             }
@@ -60,5 +60,5 @@ impl<T : BitInt> PieceProcessor<T> for KnightProcess {
 }
 
 pub fn create_knight<T : BitInt>() -> Piece<T> {
-    Piece::new("n", "knight", Box::new(KnightProcess))
+    Piece::new("n", "knight", Box::new(KnightRules))
 }

--- a/src/chess/pieces/pawn.rs
+++ b/src/chess/pieces/pawn.rs
@@ -1,9 +1,9 @@
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{index_to_square, make_chess_move, Action, ActionRecord}, piece::{Piece, PieceProcessor}, Board, BoardState, Team}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{index_to_square, make_chess_move, Action, ActionRecord}, piece::{Piece, PieceRules}, Board, BoardState, Team}};
 
 #[inline(always)]
 fn list_white_pawn_captures<T : BitInt>(board: &mut Board<T>, piece_index: usize) -> BitBoard<T> {
     let pawns = board.state.pieces[piece_index];
-    let edges = board.edges[0];
+    let edges = board.game.edges[0];
 
     let up_once = pawns.and(board.state.white).up(1);
     let left_captures = up_once.and_not(edges.left).left(1);
@@ -15,7 +15,7 @@ fn list_white_pawn_captures<T : BitInt>(board: &mut Board<T>, piece_index: usize
 #[inline(always)]
 fn list_black_pawn_captures<T: BitInt>(board: &mut Board<T>, piece_index: usize) -> BitBoard<T> {
     let pawns = board.state.pieces[piece_index];
-    let edges = board.edges[0];
+    let edges = board.game.edges[0];
 
     let down_once = pawns.and(board.state.black).down(1);
     let left_captures = down_once.and_not(edges.left).left(1);
@@ -50,7 +50,7 @@ fn add_black_action<T: BitInt>(board: &mut Board<T>, actions: &mut Vec<Action>, 
 
 #[inline(always)]
 fn list_white_pawn_actions<T: BitInt>(board: &mut Board<T>, piece_index: usize) -> Vec<Action> {
-    let edges = board.edges[0];
+    let edges = board.game.edges[0];
 
     let white = board.state.white;
     let black = board.state.black;
@@ -118,7 +118,7 @@ fn list_white_pawn_actions<T: BitInt>(board: &mut Board<T>, piece_index: usize) 
 
 #[inline(always)]
 fn list_black_pawn_actions<T: BitInt>(board: &mut Board<T>, piece_index: usize) -> Vec<Action> {
-    let edges = board.edges[0];
+    let edges = board.game.edges[0];
 
     let white = board.state.white;
     let black = board.state.black;
@@ -281,11 +281,11 @@ fn make_promotion_move<T: BitInt>(state: &mut BoardState<T>, action: Action) {
 }
 
 
-pub struct PawnProcess;
+pub struct PawnRules;
 
-impl<T : BitInt> PieceProcessor<T> for PawnProcess {
-    fn process(&self, board: &mut Board<T>, piece_index: usize) {
-        let edges = board.edges[0];
+impl<T : BitInt> PieceRules<T> for PawnRules {
+    fn load(&self, board: &mut Board<T>, piece_index: usize) {
+        let edges = board.game.edges[0];
 
         let pawns = board.state.pieces[piece_index];
 
@@ -332,5 +332,5 @@ impl<T : BitInt> PieceProcessor<T> for PawnProcess {
 }
 
 pub fn create_pawn<T : BitInt>() -> Piece<T> {
-    Piece::new("p", "pawn", Box::new(PawnProcess))
+    Piece::new("p", "pawn", Box::new(PawnRules))
 }

--- a/src/chess/pieces/sliders/bishop.rs
+++ b/src/chess/pieces/sliders/bishop.rs
@@ -1,5 +1,5 @@
 
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceProcessor}, Board}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceRules}, Board, Game}};
 
 use super::{ray_attacks_backward, ray_attacks_forward, repeat};
 
@@ -9,12 +9,12 @@ const DOWN_RIGHT: usize = 2;
 const DOWN_LEFT: usize = 3;
 const ALL: usize = 4;
 
-pub struct BishopProcess;
+pub struct BishopRules;
 
-impl<T : BitInt> PieceProcessor<T> for BishopProcess {
-    fn process(&self, board: &mut Board<T>, piece_index: usize) {
-        let edges = board.edges[0];
-        board.lookup[piece_index] = vec![ vec![]; 5 ];
+impl<T : BitInt> PieceRules<T> for BishopRules {
+    fn process(&self, game: &mut Game<T>, piece_index: usize) {
+        let edges = game.edges[0];
+        game.lookup[piece_index] = vec![ vec![]; 5 ];
 
         for index in 0..64 {
             let bishop = BitBoard::index(index);
@@ -24,14 +24,14 @@ impl<T : BitInt> PieceProcessor<T> for BishopProcess {
             let down_right_ray = repeat(bishop, |pos| pos.and_not(edges.bottom).and_not(edges.right).down(1).right(1));
             let down_left_ray = repeat(bishop, |pos| pos.and_not(edges.bottom).and_not(edges.left).down(1).left(1));
 
-            board.lookup[piece_index][UP_RIGHT].push(up_right_ray);
-            board.lookup[piece_index][UP_LEFT].push(up_left_ray);
-            board.lookup[piece_index][DOWN_RIGHT].push(down_right_ray);
-            board.lookup[piece_index][DOWN_LEFT].push(down_left_ray);
+            game.lookup[piece_index][UP_RIGHT].push(up_right_ray);
+            game.lookup[piece_index][UP_LEFT].push(up_left_ray);
+            game.lookup[piece_index][DOWN_RIGHT].push(down_right_ray);
+            game.lookup[piece_index][DOWN_LEFT].push(down_left_ray);
 
             let all = up_right_ray.or(up_left_ray).or(down_right_ray).or(down_left_ray);
 
-            board.lookup[piece_index][ALL].push(all);
+            game.lookup[piece_index][ALL].push(all);
         }
     }
 
@@ -42,7 +42,7 @@ impl<T : BitInt> PieceProcessor<T> for BishopProcess {
         for bishop in board.state.pieces[piece_index].and(moving_team).iter() {
             let pos = bishop as usize;
 
-            if board.lookup[piece_index][ALL][pos].and(mask).is_empty() {
+            if board.game.lookup[piece_index][ALL][pos].and(mask).is_empty() {
                 continue;
             }
             
@@ -90,5 +90,5 @@ impl<T : BitInt> PieceProcessor<T> for BishopProcess {
 }
 
 pub fn create_bishop<T: BitInt>() -> Piece<T> {
-    Piece::new("b", "bishop", Box::new(BishopProcess))
+    Piece::new("b", "bishop", Box::new(BishopRules))
 }

--- a/src/chess/pieces/sliders/bishop.rs
+++ b/src/chess/pieces/sliders/bishop.rs
@@ -11,8 +11,8 @@ const ALL: usize = 4;
 
 pub struct BishopRules;
 
-impl<T : BitInt> PieceRules<T> for BishopRules {
-    fn process(&self, game: &mut Game<T>, piece_index: usize) {
+impl<T: BitInt, const N: usize> PieceRules<T, N> for BishopRules {
+    fn process(&self, game: &mut Game<T, N>, piece_index: usize) {
         let edges = game.edges[0];
         game.lookup[piece_index] = vec![ vec![]; 5 ];
 
@@ -35,7 +35,7 @@ impl<T : BitInt> PieceRules<T> for BishopRules {
         }
     }
 
-    fn capture_mask(&self, board: &mut Board<T>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T> {
+    fn capture_mask(&self, board: &mut Board<T, N>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T> {
         let moving_team = board.state.team_to_move();
         let mut captures = BitBoard::empty();
 
@@ -58,7 +58,7 @@ impl<T : BitInt> PieceRules<T> for BishopRules {
         captures
     }
 
-    fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action> {
+    fn list_actions(&self, board: &mut Board<T, N>, piece_index: usize) -> Vec<Action> {
         let moving_team = board.state.team_to_move();
         let bishops = board.state.pieces[piece_index];
 
@@ -83,12 +83,12 @@ impl<T : BitInt> PieceRules<T> for BishopRules {
         actions
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) {
+    fn make_move(&self, board: &mut Board<T, N>, action: Action) {
         make_chess_move(&mut board.state, action)
     }
 
 }
 
-pub fn create_bishop<T: BitInt>() -> Piece<T> {
+pub fn create_bishop<T: BitInt, const N: usize>() -> Piece<T, N> {
     Piece::new("b", "bishop", Box::new(BishopRules))
 }

--- a/src/chess/pieces/sliders/bishop.rs
+++ b/src/chess/pieces/sliders/bishop.rs
@@ -1,5 +1,5 @@
 
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action, HistoryState}, piece::{Piece, PieceProcessor}, Board}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceProcessor}, Board}};
 
 use super::{ray_attacks_backward, ray_attacks_forward, repeat};
 
@@ -83,7 +83,7 @@ impl<T : BitInt> PieceProcessor<T> for BishopProcess {
         actions
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) -> HistoryState<T> {
+    fn make_move(&self, board: &mut Board<T>, action: Action) {
         make_chess_move(&mut board.state, action)
     }
 

--- a/src/chess/pieces/sliders/mod.rs
+++ b/src/chess/pieces/sliders/mod.rs
@@ -6,7 +6,7 @@ pub mod rook;
 pub mod queen;
 
 #[inline(always)]
-pub fn ray_attacks_forward<T : BitInt>(board: &mut Board<T>, pos: usize, piece_index: usize, dir: usize) -> BitBoard<T> {
+pub fn ray_attacks_forward<T: BitInt, const N: usize>(board: &mut Board<T, N>, pos: usize, piece_index: usize, dir: usize) -> BitBoard<T> {
     let ray = board.game.lookup[piece_index][dir][pos];
 
     let blocker = ray.and(board.state.black.or(board.state.white));
@@ -19,7 +19,7 @@ pub fn ray_attacks_forward<T : BitInt>(board: &mut Board<T>, pos: usize, piece_i
 }
 
 #[inline(always)]
-pub fn ray_attacks_backward<T : BitInt>(board: &mut Board<T>, pos: usize, piece_index: usize, dir: usize) -> BitBoard<T> {
+pub fn ray_attacks_backward<T: BitInt, const N: usize>(board: &mut Board<T, N>, pos: usize, piece_index: usize, dir: usize) -> BitBoard<T> {
     let ray = board.game.lookup[piece_index][dir][pos];
 
     let blocker = ray.and(board.state.black.or(board.state.white));
@@ -31,7 +31,7 @@ pub fn ray_attacks_backward<T : BitInt>(board: &mut Board<T>, pos: usize, piece_
     }
 }
 
-pub fn repeat<T : BitInt>(mut pos: BitBoard<T>, apply: impl Fn(BitBoard<T>) -> BitBoard<T>) -> BitBoard<T> {
+pub fn repeat<T: BitInt>(mut pos: BitBoard<T>, apply: impl Fn(BitBoard<T>) -> BitBoard<T>) -> BitBoard<T> {
     let mut out = BitBoard::empty();
     loop {
         let progress = apply(pos);

--- a/src/chess/pieces/sliders/mod.rs
+++ b/src/chess/pieces/sliders/mod.rs
@@ -7,12 +7,12 @@ pub mod queen;
 
 #[inline(always)]
 pub fn ray_attacks_forward<T : BitInt>(board: &mut Board<T>, pos: usize, piece_index: usize, dir: usize) -> BitBoard<T> {
-    let ray = board.lookup[piece_index][dir][pos];
+    let ray = board.game.lookup[piece_index][dir][pos];
 
     let blocker = ray.and(board.state.black.or(board.state.white));
     if blocker.is_set() {
         let square = blocker.bitscan_forward();
-        ray.xor(board.lookup[piece_index][dir][square as usize])
+        ray.xor(board.game.lookup[piece_index][dir][square as usize])
     } else {
         ray
     }
@@ -20,12 +20,12 @@ pub fn ray_attacks_forward<T : BitInt>(board: &mut Board<T>, pos: usize, piece_i
 
 #[inline(always)]
 pub fn ray_attacks_backward<T : BitInt>(board: &mut Board<T>, pos: usize, piece_index: usize, dir: usize) -> BitBoard<T> {
-    let ray = board.lookup[piece_index][dir][pos];
+    let ray = board.game.lookup[piece_index][dir][pos];
 
     let blocker = ray.and(board.state.black.or(board.state.white));
     if blocker.is_set() {
         let square = blocker.bitscan_backward();
-        ray.xor(board.lookup[piece_index][dir][square as usize])
+        ray.xor(board.game.lookup[piece_index][dir][square as usize])
     } else {
         ray
     }

--- a/src/chess/pieces/sliders/queen.rs
+++ b/src/chess/pieces/sliders/queen.rs
@@ -17,8 +17,8 @@ const ALL: usize = 10;
 
 pub struct QueenRules;
 
-impl<T: BitInt> PieceRules<T> for QueenRules {
-    fn process(&self, game: &mut Game<T>, piece_index: usize) {
+impl<T: BitInt, const N: usize> PieceRules<T, N> for QueenRules {
+    fn process(&self, game: &mut Game<T, N>, piece_index: usize) {
         let edges = game.edges[0];
         game.lookup[piece_index] = vec![ vec![]; 11 ];
 
@@ -56,7 +56,7 @@ impl<T: BitInt> PieceRules<T> for QueenRules {
         }
     }
 
-    fn capture_mask(&self, board: &mut Board<T>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T> {
+    fn capture_mask(&self, board: &mut Board<T, N>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T> {
         let moving_team = board.state.team_to_move();
         let mut captures = BitBoard::empty();
 
@@ -93,7 +93,7 @@ impl<T: BitInt> PieceRules<T> for QueenRules {
         captures
     }
 
-    fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action> {
+    fn list_actions(&self, board: &mut Board<T, N>, piece_index: usize) -> Vec<Action> {
         let moving_team = board.state.team_to_move();
         let mut actions: Vec<Action> = Vec::with_capacity(4);
 
@@ -121,11 +121,11 @@ impl<T: BitInt> PieceRules<T> for QueenRules {
         actions
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) {
+    fn make_move(&self, board: &mut Board<T, N>, action: Action) {
         make_chess_move(&mut board.state, action)
     }
 }
 
-pub fn create_queen<T: BitInt>() -> Piece<T> {
+pub fn create_queen<T: BitInt, const N: usize>() -> Piece<T, N> {
     Piece::new("q", "queen", Box::new(QueenRules))
 }

--- a/src/chess/pieces/sliders/queen.rs
+++ b/src/chess/pieces/sliders/queen.rs
@@ -1,5 +1,5 @@
 
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceProcessor}, Board}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceRules}, Board, Game}};
 
 use super::{ray_attacks_backward, ray_attacks_forward, repeat};
 
@@ -15,12 +15,12 @@ const SIDES: usize = 8;
 const DIAGONALS: usize = 9;
 const ALL: usize = 10;
 
-pub struct QueenProcess;
+pub struct QueenRules;
 
-impl<T: BitInt> PieceProcessor<T> for QueenProcess {
-    fn process(&self, board: &mut Board<T>, piece_index: usize) {
-        let edges = board.edges[0];
-        board.lookup[piece_index] = vec![ vec![]; 11 ];
+impl<T: BitInt> PieceRules<T> for QueenRules {
+    fn process(&self, game: &mut Game<T>, piece_index: usize) {
+        let edges = game.edges[0];
+        game.lookup[piece_index] = vec![ vec![]; 11 ];
 
         for index in 0..64 {
             let queen = BitBoard::index(index);
@@ -35,24 +35,24 @@ impl<T: BitInt> PieceProcessor<T> for QueenProcess {
             let down_right_ray = repeat(queen, |pos| pos.and_not(edges.bottom).and_not(edges.right).down(1).right(1));
             let down_left_ray = repeat(queen, |pos| pos.and_not(edges.bottom).and_not(edges.left).down(1).left(1));
             
-            board.lookup[piece_index][UP].push(up_ray);
-            board.lookup[piece_index][DOWN].push(down_ray);
-            board.lookup[piece_index][LEFT].push(left_ray);
-            board.lookup[piece_index][RIGHT].push(right_ray);
+            game.lookup[piece_index][UP].push(up_ray);
+            game.lookup[piece_index][DOWN].push(down_ray);
+            game.lookup[piece_index][LEFT].push(left_ray);
+            game.lookup[piece_index][RIGHT].push(right_ray);
 
-            board.lookup[piece_index][UP_RIGHT].push(up_right_ray);
-            board.lookup[piece_index][UP_LEFT].push(up_left_ray);
-            board.lookup[piece_index][DOWN_RIGHT].push(down_right_ray);
-            board.lookup[piece_index][DOWN_LEFT].push(down_left_ray);
+            game.lookup[piece_index][UP_RIGHT].push(up_right_ray);
+            game.lookup[piece_index][UP_LEFT].push(up_left_ray);
+            game.lookup[piece_index][DOWN_RIGHT].push(down_right_ray);
+            game.lookup[piece_index][DOWN_LEFT].push(down_left_ray);
 
             let sides = up_ray.or(down_ray).or(left_ray).or(right_ray);
             let diagonals = up_right_ray.or(up_left_ray).or(down_right_ray).or(down_left_ray);
 
             let all = sides.or(diagonals);
             
-            board.lookup[piece_index][SIDES].push(sides);
-            board.lookup[piece_index][DIAGONALS].push(diagonals);
-            board.lookup[piece_index][ALL].push(all);
+            game.lookup[piece_index][SIDES].push(sides);
+            game.lookup[piece_index][DIAGONALS].push(diagonals);
+            game.lookup[piece_index][ALL].push(all);
         }
     }
 
@@ -63,13 +63,13 @@ impl<T: BitInt> PieceProcessor<T> for QueenProcess {
         for queen in board.state.pieces[piece_index].and(moving_team).iter() {
             let pos = queen as usize;
             
-            if board.lookup[piece_index][ALL][pos].and(mask).is_empty() {
+            if board.game.lookup[piece_index][ALL][pos].and(mask).is_empty() {
                 continue;
             }
 
             let mut moves = BitBoard::empty();
             
-            if board.lookup[piece_index][SIDES][pos].and(mask).is_set() {
+            if board.game.lookup[piece_index][SIDES][pos].and(mask).is_set() {
                 let up = ray_attacks_forward(board, pos, piece_index, UP);
                 let down = ray_attacks_backward(board, pos, piece_index, DOWN);
                 let left = ray_attacks_backward(board, pos, piece_index, LEFT);
@@ -78,7 +78,7 @@ impl<T: BitInt> PieceProcessor<T> for QueenProcess {
                 moves = moves.or(up).or(down).or(left).or(right);
             }
 
-            if board.lookup[piece_index][DIAGONALS][pos].and(mask).is_set() {
+            if board.game.lookup[piece_index][DIAGONALS][pos].and(mask).is_set() {
                 let up_right = ray_attacks_forward(board, pos, piece_index, UP_RIGHT);
                 let up_left = ray_attacks_forward(board, pos, piece_index, UP_LEFT);
                 let down_right = ray_attacks_backward(board, pos, piece_index, DOWN_RIGHT);
@@ -127,5 +127,5 @@ impl<T: BitInt> PieceProcessor<T> for QueenProcess {
 }
 
 pub fn create_queen<T: BitInt>() -> Piece<T> {
-    Piece::new("q", "queen", Box::new(QueenProcess))
+    Piece::new("q", "queen", Box::new(QueenRules))
 }

--- a/src/chess/pieces/sliders/queen.rs
+++ b/src/chess/pieces/sliders/queen.rs
@@ -1,5 +1,5 @@
 
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action, HistoryState}, piece::{Piece, PieceProcessor}, Board}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceProcessor}, Board}};
 
 use super::{ray_attacks_backward, ray_attacks_forward, repeat};
 
@@ -121,7 +121,7 @@ impl<T: BitInt> PieceProcessor<T> for QueenProcess {
         actions
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) -> HistoryState<T> {
+    fn make_move(&self, board: &mut Board<T>, action: Action) {
         make_chess_move(&mut board.state, action)
     }
 }

--- a/src/chess/pieces/sliders/rook.rs
+++ b/src/chess/pieces/sliders/rook.rs
@@ -11,8 +11,8 @@ const ALL: usize = 4;
 
 pub struct RookRules;
 
-impl<T: BitInt> PieceRules<T> for RookRules {
-    fn process(&self, game: &mut Game<T>, piece_index: usize) {
+impl<T: BitInt, const N: usize> PieceRules<T, N> for RookRules {
+    fn process(&self, game: &mut Game<T, N>, piece_index: usize) {
         let edges = game.edges[0];
         game.lookup[piece_index] = vec![ vec![]; 5 ];
 
@@ -35,7 +35,7 @@ impl<T: BitInt> PieceRules<T> for RookRules {
         }
     }
 
-    fn capture_mask(&self, board: &mut Board<T>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T> {
+    fn capture_mask(&self, board: &mut Board<T, N>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T> {
         let moving_team = board.state.team_to_move();
         let mut captures = BitBoard::empty();
 
@@ -58,7 +58,7 @@ impl<T: BitInt> PieceRules<T> for RookRules {
         captures
     }
 
-    fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action> {
+    fn list_actions(&self, board: &mut Board<T, N>, piece_index: usize) -> Vec<Action> {
         let moving_team = board.state.team_to_move();
         let mut actions: Vec<Action> = Vec::with_capacity(4);
 
@@ -81,11 +81,11 @@ impl<T: BitInt> PieceRules<T> for RookRules {
         actions
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) {
+    fn make_move(&self, board: &mut Board<T, N>, action: Action) {
         make_chess_move(&mut board.state, action)
     }
 }
 
-pub fn create_rook<T: BitInt>() -> Piece<T> {
+pub fn create_rook<T: BitInt, const N: usize>() -> Piece<T, N> {
     Piece::new("r", "rook", Box::new(RookRules))
 }

--- a/src/chess/pieces/sliders/rook.rs
+++ b/src/chess/pieces/sliders/rook.rs
@@ -1,5 +1,5 @@
 
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceProcessor}, Board}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceRules}, Board, Game}};
 
 use super::{ray_attacks_backward, ray_attacks_forward, repeat};
 
@@ -9,12 +9,12 @@ const LEFT: usize = 2;
 const RIGHT: usize = 3;
 const ALL: usize = 4;
 
-pub struct RookProcess;
+pub struct RookRules;
 
-impl<T: BitInt> PieceProcessor<T> for RookProcess {
-    fn process(&self, board: &mut Board<T>, piece_index: usize) {
-        let edges = board.edges[0];
-        board.lookup[piece_index] = vec![ vec![]; 5 ];
+impl<T: BitInt> PieceRules<T> for RookRules {
+    fn process(&self, game: &mut Game<T>, piece_index: usize) {
+        let edges = game.edges[0];
+        game.lookup[piece_index] = vec![ vec![]; 5 ];
 
         for index in 0..64 {
             let rook = BitBoard::index(index);
@@ -26,12 +26,12 @@ impl<T: BitInt> PieceProcessor<T> for RookProcess {
 
             let all = up_ray.or(down_ray).or(left_ray).or(right_ray);
 
-            board.lookup[piece_index][UP].push(up_ray);
-            board.lookup[piece_index][DOWN].push(down_ray);
-            board.lookup[piece_index][LEFT].push(left_ray);
-            board.lookup[piece_index][RIGHT].push(right_ray);
+            game.lookup[piece_index][UP].push(up_ray);
+            game.lookup[piece_index][DOWN].push(down_ray);
+            game.lookup[piece_index][LEFT].push(left_ray);
+            game.lookup[piece_index][RIGHT].push(right_ray);
 
-            board.lookup[piece_index][ALL].push(all);
+            game.lookup[piece_index][ALL].push(all);
         }
     }
 
@@ -42,7 +42,7 @@ impl<T: BitInt> PieceProcessor<T> for RookProcess {
         for rook in board.state.pieces[piece_index].and(moving_team).iter() {
             let pos = rook as usize;
 
-            if board.lookup[piece_index][ALL][pos].and(mask).is_empty() {
+            if board.game.lookup[piece_index][ALL][pos].and(mask).is_empty() {
                 continue;
             }
             
@@ -87,5 +87,5 @@ impl<T: BitInt> PieceProcessor<T> for RookProcess {
 }
 
 pub fn create_rook<T: BitInt>() -> Piece<T> {
-    Piece::new("r", "rook", Box::new(RookProcess))
+    Piece::new("r", "rook", Box::new(RookRules))
 }

--- a/src/chess/pieces/sliders/rook.rs
+++ b/src/chess/pieces/sliders/rook.rs
@@ -1,5 +1,5 @@
 
-use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action, HistoryState}, piece::{Piece, PieceProcessor}, Board}};
+use crate::{bitboard::{BitBoard, BitInt}, game::{action::{make_chess_move, Action}, piece::{Piece, PieceProcessor}, Board}};
 
 use super::{ray_attacks_backward, ray_attacks_forward, repeat};
 
@@ -81,7 +81,7 @@ impl<T: BitInt> PieceProcessor<T> for RookProcess {
         actions
     }
 
-    fn make_move(&self, board: &mut Board<T>, action: Action) -> HistoryState<T> {
+    fn make_move(&self, board: &mut Board<T>, action: Action) {
         make_chess_move(&mut board.state, action)
     }
 }

--- a/src/chess/suite.rs
+++ b/src/chess/suite.rs
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn chess() {
-        let chess = Chess::create::<u64>();
+        let chess = Chess::create::<u64, 6>();
         test_suite(CHESS_SUITE, &chess);
     }
 }

--- a/src/game/action.rs
+++ b/src/game/action.rs
@@ -59,51 +59,13 @@ impl Action {
     }
 }
 
-#[derive(Clone, Copy)]
-pub enum HistoryUpdate<T : BitInt> {
-    White(BitBoard<T>),
-    Black(BitBoard<T>),
-    FirstMove(BitBoard<T>),
-    Piece(u8, BitBoard<T>),
-    Mailbox(u8, u8)
-}
-
-#[derive(Clone)]
-
-pub struct HistoryState<T : BitInt> (pub Vec<HistoryUpdate<T>>);
-
-pub fn restore_perfectly<T : BitInt>(board: &mut Board<T>) -> HistoryState<T> {
-    let squares = (board.game.bounds.rows * board.game.bounds.cols) as usize;
-    let pieces = board.game.pieces.len();
-
-    let mut updates = vec![];
-
-    for square in 0..squares {
-        updates.push(HistoryUpdate::Mailbox(square as u8, board.state.mailbox[square]));
-    }
-
-    for piece in 0..pieces {
-        updates.push(HistoryUpdate::Piece(piece as u8, board.state.pieces[piece]));
-    }
-    
-    updates.push(HistoryUpdate::White(board.state.white));
-    updates.push(HistoryUpdate::Black(board.state.black));
-    updates.push(HistoryUpdate::FirstMove(board.state.first_move));
-
-    HistoryState(updates)
-}
-
 #[inline(always)]
-pub fn make_chess_move<T : BitInt>(state: &mut BoardState<T>, action: Action) -> HistoryState<T> {
+pub fn make_chess_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
     let to_idx = action.to as usize;
     let from_idx = action.from as usize;
 
-    let mut updates: Vec<HistoryUpdate<T>> = Vec::with_capacity(7);
     let piece_index = state.mailbox[from_idx] - 1;
     let mailbox = state.mailbox[to_idx];
-
-    updates.push(HistoryUpdate::Mailbox(action.from, piece_index + 1));
-    updates.push(HistoryUpdate::Mailbox(action.to, mailbox));
     
     let from = BitBoard::index(action.from);
     let to = BitBoard::index(action.to);
@@ -113,7 +75,6 @@ pub fn make_chess_move<T : BitInt>(state: &mut BoardState<T>, action: Action) ->
 
     // Save the moved piece's old state
     let piece = state.pieces[piece_index as usize];
-    updates.push(HistoryUpdate::Piece(piece_index, piece));
 
     let white = state.white;
     let black = state.black;
@@ -125,18 +86,15 @@ pub fn make_chess_move<T : BitInt>(state: &mut BoardState<T>, action: Action) ->
         let same_piece_type = piece_type == piece_index;
         if !same_piece_type {
             let piece = state.pieces[piece_type as usize];
-            updates.push(HistoryUpdate::Piece(piece_type, piece));
             state.pieces[piece_type as usize] = piece.xor(to);
         }
 
         // Remove the captured piece from the opposite team's bitboard
         match team {
             Team::White => {
-                updates.push(HistoryUpdate::Black(black));
                 state.black = black.xor(to);
             }
             Team::Black => {
-                updates.push(HistoryUpdate::White(white));
                 state.white = white.xor(to);
             }
         }
@@ -151,19 +109,14 @@ pub fn make_chess_move<T : BitInt>(state: &mut BoardState<T>, action: Action) ->
     // Update the moved piece's team bitboard
     match team {
         Team::White => {
-            updates.push(HistoryUpdate::White(white));
             state.white = white.xor(from).or(to);
         }
         Team::Black => {
-            updates.push(HistoryUpdate::Black(black));
             state.black = black.xor(from).or(to);
         }
     }
 
     if state.first_move.and(from.or(to)).is_set() {
-        updates.push(HistoryUpdate::FirstMove(state.first_move));
         state.first_move = state.first_move.and_not(from.or(to));
     }
-
-    HistoryState(updates)
 }

--- a/src/game/action.rs
+++ b/src/game/action.rs
@@ -60,7 +60,7 @@ impl Action {
 }
 
 #[inline(always)]
-pub fn make_chess_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
+pub fn make_chess_move<T : BitInt, const N: usize>(state: &mut BoardState<T, N>, action: Action) {
     let piece_index = action.piece as usize;
     let victim_index = state.piece_at(action.to);
     

--- a/src/game/action.rs
+++ b/src/game/action.rs
@@ -61,17 +61,13 @@ impl Action {
 
 #[inline(always)]
 pub fn make_chess_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
-    let to_idx = action.to as usize;
-    let from_idx = action.from as usize;
-
-    let piece_index = state.mailbox[from_idx] - 1;
-    let mailbox = state.mailbox[to_idx];
+    let piece_index = action.piece as usize;
+    let victim_index = state.piece_at(action.to);
     
     let from = BitBoard::index(action.from);
     let to = BitBoard::index(action.to);
 
     let team = state.moving_team;
-    let is_capture = mailbox > 0;
 
     // Save the moved piece's old state
     let piece = state.pieces[piece_index as usize];
@@ -79,9 +75,7 @@ pub fn make_chess_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
     let white = state.white;
     let black = state.black;
 
-    if is_capture {
-        let piece_type = mailbox - 1;
-
+    if let Some(piece_type) = victim_index {
         // Remove the captured piece type from its bitboard
         let same_piece_type = piece_type == piece_index;
         if !same_piece_type {
@@ -102,9 +96,6 @@ pub fn make_chess_move<T : BitInt>(state: &mut BoardState<T>, action: Action) {
 
     // Update the moved piece's piece bitboard
     state.pieces[piece_index as usize] = piece.xor(from).or(to);
-
-    state.mailbox[from_idx] = 0;
-    state.mailbox[to_idx] = piece_index + 1;
 
     // Update the moved piece's team bitboard
     match team {

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -112,9 +112,9 @@ pub struct BoardState<T : BitInt> {
 
     pub white: BitBoard<T>,
     pub black: BitBoard<T>,
-    pub pieces: Vec<BitBoard<T>>,
+    pub pieces: Box<[BitBoard<T>]>,
 
-    pub mailbox: Vec<u8>
+    pub mailbox: Box<[u8]>,
 }
 
 impl<T : BitInt> BoardState<T> {
@@ -124,8 +124,8 @@ impl<T : BitInt> BoardState<T> {
             black: BitBoard::empty(),
             white: BitBoard::empty(),
             first_move: BitBoard::empty(),
-            pieces: vec![BitBoard::empty(); 6],
-            mailbox: vec![]
+            pieces: vec![BitBoard::empty(); 6].into_boxed_slice(),
+            mailbox: vec![0; 64].into_boxed_slice()
         }
     }
 
@@ -159,10 +159,6 @@ impl<'a, T : BitInt> Board<'a, T> {
     }
 
     pub fn load(&mut self, pos: &str) {
-        for _ in 0..(self.game.bounds.rows * self.game.bounds.cols) {
-            self.state.mailbox.push(0);
-        }
-
         self.game.rules.load(self, pos);
 
         for index in 0..self.game.pieces.len() {

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -97,9 +97,6 @@ impl Team {
 pub struct Board<'a, T : BitInt> {
     pub game: &'a Game<T>,
     pub state: BoardState<T>,
-    pub piece_map: HashMap<String, usize>,
-    /// A cache of important piece indexes guaranteed by the game processor.
-    pub required_pieces: Vec<usize>,
     pub history: Vec<ActionRecord>
 }
 
@@ -157,26 +154,13 @@ impl<'a, T : BitInt> Board<'a, T> {
         Self {
             game,
             state: BoardState::new(),
-            piece_map: HashMap::default(),
-            required_pieces: vec![],
             history: vec![]
         }
-    }
-
-    /// Since variants are supported as a first-class feature, the index of a given piece type might not be fixed.
-    /// `piece_map` allows for easy access of other pieces based on names, avoiding conflicts.
-    #[inline(always)]
-    pub fn find_piece(&self, name: &str) -> Option<usize> {
-        self.piece_map.get(name).copied()
     }
 
     pub fn load(&mut self, pos: &str) {
         for _ in 0..(self.game.bounds.rows * self.game.bounds.cols) {
             self.state.mailbox.push(0);
-        }
-
-        for (index, piece) in self.game.pieces.iter().enumerate() {
-            self.piece_map.insert(piece.name.clone(), index);
         }
 
         self.game.rules.load(self, pos);

--- a/src/game/perft.rs
+++ b/src/game/perft.rs
@@ -11,14 +11,17 @@ impl<'a, T : BitInt> Board<'a, T> {
     
         let mut nodes = 0;
         for action in actions {
-            let mut board = self.play(action);
-            let is_legal = board.game.rules.is_legal(&mut board);
+            let state = self.play(action);
+            let is_legal = self.game.rules.is_legal(self);
     
             if !is_legal {
+                self.restore(state);
                 continue;
             }
     
-            let sub_nodes = board.perft(depth - 1);
+            let sub_nodes = self.perft(depth - 1);
+            self.restore(state);
+
             nodes += sub_nodes;
         }
         nodes

--- a/src/game/perft.rs
+++ b/src/game/perft.rs
@@ -12,7 +12,7 @@ impl<'a, T : BitInt> Board<'a, T> {
         let mut nodes = 0;
         for action in actions {
             let mut board = self.play(action);
-            let is_legal = board.game.processor.is_legal(&mut board);
+            let is_legal = board.game.rules.is_legal(&mut board);
     
             if !is_legal {
                 continue;

--- a/src/game/perft.rs
+++ b/src/game/perft.rs
@@ -11,18 +11,15 @@ impl<'a, T : BitInt> Board<'a, T> {
     
         let mut nodes = 0;
         for action in actions {
-            let history = self.play(action);
-            let is_legal = self.game.processor.is_legal(self);
+            let mut board = self.play(action);
+            let is_legal = board.game.processor.is_legal(&mut board);
     
             if !is_legal {
-                self.state.restore(history);
                 continue;
             }
     
-            let sub_nodes = self.perft(depth - 1);
+            let sub_nodes = board.perft(depth - 1);
             nodes += sub_nodes;
-    
-            self.state.restore(history);
         }
         nodes
     }

--- a/src/game/perft.rs
+++ b/src/game/perft.rs
@@ -3,7 +3,7 @@ use crate::bitboard::BitInt;
 
 use super::Board;
 
-impl<'a, T : BitInt> Board<'a, T> {
+impl<'a, T : BitInt, const N: usize> Board<'a, T, N> {
     pub fn perft(&mut self, depth: usize) -> usize {
         if depth == 0 { return 1; }
     

--- a/src/game/piece.rs
+++ b/src/game/piece.rs
@@ -2,7 +2,7 @@
 
 use crate::{bitboard::{BitBoard, BitInt}, game::action::index_to_square};
 
-use super::{action::{Action, HistoryState}, Board};
+use super::{action::Action, Board};
 
 /// `PieceProcessor` handles making piece-specific changes to the board.
 /// For instance, `PieceProcessor` is where the generation of a piece's lookup table happens.
@@ -10,7 +10,7 @@ pub trait PieceProcessor<T : BitInt> {
     fn process(&self, _board: &mut Board<T>, _piece_index: usize) {}
     
     fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action>;
-    fn make_move(&self, board: &mut Board<T>, action: Action) -> HistoryState<T>;
+    fn make_move(&self, board: &mut Board<T>, action: Action);
 
     fn display_action(&self, _board: &mut Board<T>, action: Action) -> Vec<String> {
         vec![
@@ -49,7 +49,7 @@ impl<T : BitInt> PieceProcessor<T> for EmptyPieceProcessor {
     fn list_actions(&self, _: &mut Board<T>, _: usize) -> Vec<Action> {
         vec![]
     }
-    fn make_move(&self, _: &mut Board<T>, _: Action) -> HistoryState<T> {
+    fn make_move(&self, _: &mut Board<T>, _: Action) {
         unimplemented!("No make_move implemented.");
     }
     fn capture_mask(&self, _: &mut Board<T>, _: usize, _: BitBoard<T>) -> BitBoard<T> {

--- a/src/game/piece.rs
+++ b/src/game/piece.rs
@@ -6,35 +6,35 @@ use super::{action::Action, Board, Game};
 
 /// `PieceRules` handles making piece-specific changes to the board.
 /// For instance, `PieceRules` is where the generation of a piece's lookup table happens.
-pub trait PieceRules<T : BitInt> {
-    fn process(&self, _game: &mut Game<T>, _piece_index: usize) {}
-    fn load(&self, _board: &mut Board<T>, _piece_index: usize) {}
+pub trait PieceRules<T : BitInt, const N: usize> {
+    fn process(&self, _game: &mut Game<T, N>, _piece_index: usize) {}
+    fn load(&self, _board: &mut Board<T, N>, _piece_index: usize) {}
     
-    fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action>;
-    fn make_move(&self, board: &mut Board<T>, action: Action);
+    fn list_actions(&self, board: &mut Board<T, N>, piece_index: usize) -> Vec<Action>;
+    fn make_move(&self, board: &mut Board<T, N>, action: Action);
 
-    fn display_action(&self, _board: &mut Board<T>, action: Action) -> Vec<String> {
+    fn display_action(&self, _board: &mut Board<T, N>, action: Action) -> Vec<String> {
         vec![
             format!("{}{}", index_to_square(action.from), index_to_square(action.to))
         ]
     }
 
-    fn display_uci_action(&self, board: &mut Board<T>, action: Action) -> String {
+    fn display_uci_action(&self, board: &mut Board<T, N>, action: Action) -> String {
         self.display_action(board, action)[0].clone()
     }
 
     /// Only useful for chess; allows us to optimize checks
-    fn capture_mask(&self, board: &mut Board<T>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T>;
+    fn capture_mask(&self, board: &mut Board<T, N>, piece_index: usize, mask: BitBoard<T>) -> BitBoard<T>;
 }
 
-pub struct Piece<T : BitInt> {
+pub struct Piece<T : BitInt, const N: usize> {
     pub symbol: String,
     pub name: String,
-    pub rules: Box<dyn PieceRules<T>>
+    pub rules: Box<dyn PieceRules<T, N>>
 }
 
-impl<T : BitInt> Piece<T> {
-    pub fn new(symbol: &str, name: &str, processor: Box<dyn PieceRules<T>>) -> Piece<T> {
+impl<T : BitInt, const N: usize> Piece<T, N> {
+    pub fn new(symbol: &str, name: &str, processor: Box<dyn PieceRules<T, N>>) -> Piece<T, N> {
         Piece {
             symbol: symbol.to_string(),
             name: name.to_string(),
@@ -45,15 +45,15 @@ impl<T : BitInt> Piece<T> {
 
 pub struct EmptyPieceRules;
 
-impl<T : BitInt> PieceRules<T> for EmptyPieceRules {
-    fn process(&self, _: &mut Game<T>, _: usize) {}
-    fn list_actions(&self, _: &mut Board<T>, _: usize) -> Vec<Action> {
+impl<T : BitInt, const N: usize> PieceRules<T, N> for EmptyPieceRules {
+    fn process(&self, _: &mut Game<T, N>, _: usize) {}
+    fn list_actions(&self, _: &mut Board<T, N>, _: usize) -> Vec<Action> {
         vec![]
     }
-    fn make_move(&self, _: &mut Board<T>, _: Action) {
+    fn make_move(&self, _: &mut Board<T, N>, _: Action) {
         unimplemented!("No make_move implemented.");
     }
-    fn capture_mask(&self, _: &mut Board<T>, _: usize, _: BitBoard<T>) -> BitBoard<T> {
+    fn capture_mask(&self, _: &mut Board<T, N>, _: usize, _: BitBoard<T>) -> BitBoard<T> {
         BitBoard::empty()
     }
 }

--- a/src/game/piece.rs
+++ b/src/game/piece.rs
@@ -2,12 +2,13 @@
 
 use crate::{bitboard::{BitBoard, BitInt}, game::action::index_to_square};
 
-use super::{action::Action, Board};
+use super::{action::Action, Board, Game};
 
-/// `PieceProcessor` handles making piece-specific changes to the board.
-/// For instance, `PieceProcessor` is where the generation of a piece's lookup table happens.
-pub trait PieceProcessor<T : BitInt> {
-    fn process(&self, _board: &mut Board<T>, _piece_index: usize) {}
+/// `PieceRules` handles making piece-specific changes to the board.
+/// For instance, `PieceRules` is where the generation of a piece's lookup table happens.
+pub trait PieceRules<T : BitInt> {
+    fn process(&self, _game: &mut Game<T>, _piece_index: usize) {}
+    fn load(&self, _board: &mut Board<T>, _piece_index: usize) {}
     
     fn list_actions(&self, board: &mut Board<T>, piece_index: usize) -> Vec<Action>;
     fn make_move(&self, board: &mut Board<T>, action: Action);
@@ -29,23 +30,23 @@ pub trait PieceProcessor<T : BitInt> {
 pub struct Piece<T : BitInt> {
     pub symbol: String,
     pub name: String,
-    pub processor: Box<dyn PieceProcessor<T>>
+    pub rules: Box<dyn PieceRules<T>>
 }
 
 impl<T : BitInt> Piece<T> {
-    pub fn new(symbol: &str, name: &str, processor: Box<dyn PieceProcessor<T>>) -> Piece<T> {
+    pub fn new(symbol: &str, name: &str, processor: Box<dyn PieceRules<T>>) -> Piece<T> {
         Piece {
             symbol: symbol.to_string(),
             name: name.to_string(),
-            processor
+            rules: processor
         }
     }
 }
 
-pub struct EmptyPieceProcessor;
+pub struct EmptyPieceRules;
 
-impl<T : BitInt> PieceProcessor<T> for EmptyPieceProcessor {
-    fn process(&self, _: &mut Board<T>, _: usize) {}
+impl<T : BitInt> PieceRules<T> for EmptyPieceRules {
+    fn process(&self, _: &mut Game<T>, _: usize) {}
     fn list_actions(&self, _: &mut Board<T>, _: usize) -> Vec<Action> {
         vec![]
     }

--- a/src/game/suite.rs
+++ b/src/game/suite.rs
@@ -31,7 +31,7 @@ pub fn parse_suite(positions: &str) -> Vec<Position> {
     out
 }
 
-pub fn test_suite<'a, T : BitInt>(positions: &str, game: &Game<T>) {
+pub fn test_suite<'a, T : BitInt, const N: usize>(positions: &str, game: &Game<T, N>) {
     let positions = parse_suite(positions);
     let mut total_nodes = 0;
 

--- a/src/game/zobrist.rs
+++ b/src/game/zobrist.rs
@@ -3,7 +3,7 @@ use crate::bitboard::BitInt;
 use super::{Board, Team};
 
 #[inline(always)]
-fn get_index<T: BitInt>(board: &Board<T>, team: Team, piece: usize, square: usize) -> usize {
+fn get_index<T: BitInt, const N: usize>(board: &Board<T, N>, team: Team, piece: usize, square: usize) -> usize {
     let pieces = board.game.pieces.len();
     let squares = (board.game.bounds.cols * board.game.bounds.rows) as usize;
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,5 +4,5 @@ pub fn main() {
     let chess = Chess::create::<u64>();
     let mut board = chess.default();
 
-    println!("{}", board.perft(4));
+    println!("{}", board.perft(5));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,8 @@
+use chessing::{chess::Chess, game::GameTemplate};
+
+pub fn main() {
+    let chess = Chess::create::<u64>();
+    let mut board = chess.default();
+
+    println!("{}", board.perft(4));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,0 @@
-use chessing::{chess::Chess, game::GameTemplate};
-
-pub fn main() {
-    let chess = Chess::create::<u64>();
-    let mut board = chess.default();
-
-    println!("{}", board.perft(5));
-}


### PR DESCRIPTION
- Move-making is no longer handled with management of `HistoryState` to revert changed BitBoards, but instead copies and reverts the entire board state.
- `piece_map` is removed (assuming Games will always use Pieces that are compatible.)
- Redundant mailbox is removed.
- Piece count is now managed as a const generic for performance.